### PR TITLE
Bracket: launch from expansion page with filter-aware sidebar picker

### DIFF
--- a/web/src/app/api/bracket/from-set/route.ts
+++ b/web/src/app/api/bracket/from-set/route.ts
@@ -1,0 +1,43 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getBracketCardsForSet } from "@/lib/bracket";
+import { seededShuffle } from "@/lib/seeded-random";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(req: NextRequest) {
+  const sp = req.nextUrl.searchParams;
+  const setCode = sp.get("set_code");
+  if (!setCode) {
+    return NextResponse.json({ error: "set_code required" }, { status: 400 });
+  }
+
+  const raritiesParam = sp.get("rarities") ?? "";
+  const rarities = raritiesParam.split(",").map((s) => s.trim()).filter(Boolean);
+  const printingRaw = sp.get("printing") ?? "all";
+  const printing = printingRaw === "new" || printingRaw === "reprints" ? printingRaw : "all";
+  const sizeRaw = sp.get("size") ?? "all";
+  const seed = sp.get("seed") ?? "default";
+
+  const pool = await getBracketCardsForSet(setCode, {
+    rarities: rarities.length > 0 ? rarities : undefined,
+    printing,
+  });
+
+  if (pool.length < 2) {
+    return NextResponse.json({ cards: [], error: "Not enough cards for a bracket" }, { status: 200 });
+  }
+
+  const shuffled = seededShuffle(pool, seed);
+
+  let cards = shuffled;
+  if (sizeRaw !== "all") {
+    const size = parseInt(sizeRaw, 10);
+    if (Number.isFinite(size) && size >= 2 && size <= 1024) {
+      cards = shuffled.slice(0, Math.min(size, shuffled.length));
+    }
+  } else {
+    cards = shuffled.slice(0, Math.min(1024, shuffled.length));
+  }
+
+  return NextResponse.json({ cards });
+}

--- a/web/src/app/bracket/BracketPageClient.tsx
+++ b/web/src/app/bracket/BracketPageClient.tsx
@@ -48,6 +48,11 @@ function shuffle<T>(arr: T[]): T[] {
 export default function BracketPageClient() {
   const searchParams = useSearchParams();
   const brewSlug = searchParams.get("brew");
+  const setCodeParam = searchParams.get("set_code");
+  const raritiesParam = searchParams.get("rarities");
+  const printingParam = searchParams.get("printing");
+  const sizeParam = searchParams.get("size");
+  const seedParam = searchParams.get("seed");
 
   const [cards, setCards] = useState<BracketCard[] | null>(null);
   const [slug, setSlug] = useState<string>("test");
@@ -59,6 +64,57 @@ export default function BracketPageClient() {
     let cancelled = false;
 
     async function load() {
+      // Set-filtered bracket — URL params fully describe the pool, so the
+      // (set+filters+size+seed) tuple is the shareable identity.
+      if (setCodeParam) {
+        const localSlug = `set-${setCodeParam}-${raritiesParam ?? ""}-${printingParam ?? "all"}-${sizeParam ?? "all"}-${seedParam ?? ""}`;
+        const cardsKey = `mtgink_bracket_cards_${localSlug}`;
+        const savedJson = typeof window !== "undefined" ? localStorage.getItem(cardsKey) : null;
+        if (savedJson) {
+          try {
+            const parsed = JSON.parse(savedJson) as BracketCard[];
+            if (Array.isArray(parsed) && parsed.length >= 2) {
+              if (!cancelled) {
+                setSlug(localSlug);
+                setCards(parsed);
+                setBracketName(`${setCodeParam.toUpperCase()} Bracket`);
+              }
+              return;
+            }
+          } catch {
+            /* ignore */
+          }
+        }
+        try {
+          const apiParams = new URLSearchParams();
+          apiParams.set("set_code", setCodeParam);
+          if (raritiesParam) apiParams.set("rarities", raritiesParam);
+          if (printingParam) apiParams.set("printing", printingParam);
+          if (sizeParam) apiParams.set("size", sizeParam);
+          if (seedParam) apiParams.set("seed", seedParam);
+          const res = await fetch(`/api/bracket/from-set?${apiParams.toString()}`);
+          if (!res.ok) throw new Error("Failed to build bracket");
+          const data = await res.json();
+          const fetched = (data.cards ?? []) as BracketCard[];
+          if (fetched.length < 2) {
+            throw new Error("Not enough cards match these filters for a bracket");
+          }
+          if (typeof window !== "undefined") {
+            localStorage.setItem(cardsKey, JSON.stringify(fetched));
+          }
+          if (!cancelled) {
+            setSlug(localSlug);
+            setCards(fetched);
+            setBracketName(`${setCodeParam.toUpperCase()} Bracket`);
+          }
+        } catch (err) {
+          if (!cancelled) {
+            setError(err instanceof Error ? err.message : "Failed to load bracket");
+          }
+        }
+        return;
+      }
+
       // Brew-backed bracket
       if (brewSlug) {
         try {
@@ -149,13 +205,25 @@ export default function BracketPageClient() {
     return () => {
       cancelled = true;
     };
-  }, [brewSlug]);
+  }, [brewSlug, setCodeParam, raritiesParam, printingParam, sizeParam, seedParam]);
 
   // Restart: clear saved bracket state + cards cache + submission guard,
   // then reload so load() picks a fresh set of cards (new random pull for
-  // random brackets, new shuffle of the pool for brew brackets).
+  // random brackets, new shuffle of the pool for brew brackets, new shuffle
+  // from filtered pool for set-filtered brackets via seed refresh).
   const handleRestart = useCallback(() => {
     if (typeof window === "undefined") return;
+    if (setCodeParam) {
+      const localSlug = `set-${setCodeParam}-${raritiesParam ?? ""}-${printingParam ?? "all"}-${sizeParam ?? "all"}-${seedParam ?? ""}`;
+      localStorage.removeItem(`mtgink_bracket_${localSlug}`);
+      localStorage.removeItem(`mtgink_bracket_cards_${localSlug}`);
+      sessionStorage.removeItem(`bracket_submitted_${localSlug}`);
+      // Refresh the URL with a new seed so the next load fetches a new shuffle
+      const nextParams = new URLSearchParams(window.location.search);
+      nextParams.set("seed", Math.random().toString(36).slice(2, 10));
+      window.location.search = nextParams.toString();
+      return;
+    }
     if (brewSlug) {
       const localSlug = `brew-${brewSlug}`;
       localStorage.removeItem(`mtgink_bracket_${localSlug}`);
@@ -167,7 +235,7 @@ export default function BracketPageClient() {
       sessionStorage.removeItem("bracket_submitted_test");
     }
     window.location.reload();
-  }, [brewSlug]);
+  }, [brewSlug, setCodeParam, raritiesParam, printingParam, sizeParam, seedParam]);
 
   const handleComplete = useCallback(async (state: BracketState) => {
     // Guard against double-submit (effect may fire twice in dev/strict mode)

--- a/web/src/app/db/layout.tsx
+++ b/web/src/app/db/layout.tsx
@@ -1,10 +1,13 @@
 import Sidebar from "@/components/Sidebar";
+import { ExpansionProvider } from "@/lib/expansion-context";
 
 export default function DbLayout({ children }: { children: React.ReactNode }) {
   return (
-    <div className="max-w-7xl mx-auto px-4 flex gap-8">
-      <div className="flex-1 min-w-0">{children}</div>
-      <Sidebar />
-    </div>
+    <ExpansionProvider>
+      <div className="max-w-7xl mx-auto px-4 flex gap-8">
+        <div className="flex-1 min-w-0">{children}</div>
+        <Sidebar />
+      </div>
+    </ExpansionProvider>
   );
 }

--- a/web/src/components/CreateBracketPanel.tsx
+++ b/web/src/components/CreateBracketPanel.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import { useRouter, useSearchParams } from "next/navigation";
+import { useMemo, useState, useEffect } from "react";
+import { useExpansionCounts } from "@/lib/expansion-context";
+import { PlayModeIcon, BRACKET_ICON } from "@/lib/play-modes";
+
+type SizeChoice = 8 | 16 | 32 | 64 | 128 | "all";
+const SIZE_OPTIONS: SizeChoice[] = [8, 16, 32, 64, 128, "all"];
+
+function makeSeed(): string {
+  return Math.random().toString(36).slice(2, 10);
+}
+
+function pickDefaultSize(count: number): SizeChoice {
+  if (count >= 32) return 32;
+  if (count >= 16) return 16;
+  if (count >= 8) return 8;
+  return "all";
+}
+
+export default function CreateBracketPanel({ compact = false }: { compact?: boolean }) {
+  const router = useRouter();
+  const { setCode, filteredCount, totalCount } = useExpansionCounts();
+  const searchParams = useSearchParams();
+
+  const hasFilters = useMemo(() => {
+    if (!searchParams) return false;
+    return Boolean(searchParams.get("rarities")) || (searchParams.get("printing") && searchParams.get("printing") !== "all");
+  }, [searchParams]);
+
+  const effectiveCount = filteredCount || totalCount;
+  const [selected, setSelected] = useState<SizeChoice>(() => pickDefaultSize(effectiveCount));
+
+  // If the filtered count drops below the currently selected size, fall back
+  // to the largest valid option so the user isn't stuck with a disabled pick.
+  useEffect(() => {
+    if (selected !== "all" && effectiveCount < selected) {
+      setSelected(pickDefaultSize(effectiveCount));
+    }
+  }, [effectiveCount, selected]);
+
+  if (!setCode) return null;
+
+  const canLaunch = effectiveCount >= 2 && (selected === "all" || effectiveCount >= selected);
+
+  const handleLaunch = () => {
+    if (!canLaunch) return;
+    const sp = new URLSearchParams();
+    sp.set("set_code", setCode);
+    const rarities = searchParams?.get("rarities");
+    if (rarities) sp.set("rarities", rarities);
+    const printing = searchParams?.get("printing");
+    if (printing && printing !== "all") sp.set("printing", printing);
+    sp.set("size", String(selected));
+    sp.set("seed", makeSeed());
+    router.push(`/bracket?${sp.toString()}`);
+  };
+
+  return (
+    <div className={compact ? "" : "bg-gray-900 border border-gray-800 rounded-lg p-4"}>
+      <h3 className="text-sm font-bold text-gray-400 uppercase tracking-wider mb-2 flex items-center gap-2">
+        <PlayModeIcon d={BRACKET_ICON} className="w-4 h-4 text-amber-400" />
+        Create Bracket
+      </h3>
+      <p className="text-xs text-gray-500 mb-3">
+        {hasFilters ? (
+          <>
+            <span className="text-amber-400 font-medium">{filteredCount}</span>
+            <span className="text-gray-500"> / {totalCount} cards after filters</span>
+          </>
+        ) : (
+          <>
+            <span className="text-gray-300 font-medium">{totalCount}</span>
+            <span className="text-gray-500"> cards — apply filters to narrow</span>
+          </>
+        )}
+      </p>
+      <div className="grid grid-cols-3 gap-1.5 mb-3">
+        {SIZE_OPTIONS.map((size) => {
+          const disabled = size !== "all" && effectiveCount < size;
+          const isSelected = selected === size;
+          const label = size === "all" ? "All" : String(size);
+          return (
+            <button
+              key={String(size)}
+              type="button"
+              onClick={() => !disabled && setSelected(size)}
+              disabled={disabled}
+              className={`flex items-center justify-center px-2 py-1.5 text-xs font-bold rounded border transition-colors ${
+                disabled
+                  ? "bg-gray-900 text-gray-700 border-gray-800 cursor-not-allowed"
+                  : isSelected
+                    ? "bg-amber-500 text-gray-900 border-amber-500 cursor-pointer"
+                    : "bg-gray-800 text-amber-400 border-amber-500/30 hover:bg-gray-700 cursor-pointer"
+              }`}
+            >
+              {label}
+            </button>
+          );
+        })}
+      </div>
+      <button
+        type="button"
+        onClick={handleLaunch}
+        disabled={!canLaunch}
+        className={`w-full flex items-center justify-center gap-2 px-3 py-2 text-xs font-bold rounded-lg transition-colors ${
+          canLaunch
+            ? "bg-amber-500 text-gray-900 hover:bg-amber-400 cursor-pointer"
+            : "bg-gray-800 text-gray-600 cursor-not-allowed"
+        }`}
+      >
+        <PlayModeIcon d={BRACKET_ICON} className="w-4 h-4" />
+        Launch Bracket
+      </button>
+      <p className="text-[10px] text-gray-600 mt-2 leading-snug">
+        Single-elimination from the filtered cards. Share the URL to play the same matchups.
+      </p>
+    </div>
+  );
+}

--- a/web/src/components/MobileBracketFab.tsx
+++ b/web/src/components/MobileBracketFab.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useExpansionCounts } from "@/lib/expansion-context";
+import { PlayModeIcon, BRACKET_ICON } from "@/lib/play-modes";
+import CreateBracketPanel from "./CreateBracketPanel";
+
+export default function MobileBracketFab() {
+  const { setCode } = useExpansionCounts();
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open]);
+
+  if (!setCode) return null;
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className="lg:hidden fixed bottom-4 right-4 z-40 flex items-center gap-2 px-4 py-3 rounded-full bg-amber-500 text-gray-900 font-bold text-sm shadow-lg shadow-black/40 hover:bg-amber-400 transition-colors cursor-pointer"
+        aria-label="Create bracket from current filters"
+      >
+        <span>Play</span>
+        <PlayModeIcon d={BRACKET_ICON} className="w-5 h-5" />
+      </button>
+      {open && (
+        <div
+          className="lg:hidden fixed inset-0 z-50 bg-black/70 flex items-end justify-center"
+          onClick={() => setOpen(false)}
+        >
+          <div
+            className="w-full max-w-md bg-gray-900 border-t border-gray-800 rounded-t-2xl p-4 pb-8"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="flex justify-center mb-3">
+              <div className="w-10 h-1 rounded-full bg-gray-700" />
+            </div>
+            <CreateBracketPanel compact />
+            <button
+              type="button"
+              onClick={() => setOpen(false)}
+              className="mt-4 w-full py-2 text-xs font-medium text-gray-400 hover:text-white cursor-pointer"
+            >
+              Close
+            </button>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/web/src/components/SetCardGrid.tsx
+++ b/web/src/components/SetCardGrid.tsx
@@ -1,8 +1,11 @@
 "use client";
 
-import { useState, useMemo } from "react";
+import { useState, useMemo, useEffect, useCallback } from "react";
+import { useRouter, usePathname, useSearchParams } from "next/navigation";
 import { useImageMode } from "@/lib/image-mode";
 import { useGridDensity, GRID_CLASSES } from "@/lib/grid-density";
+import { parseSetFilterParams, type PrintingFilter } from "@/lib/set-filters";
+import { usePublishExpansionCounts } from "@/lib/expansion-context";
 import GridDensitySelector from "./GridDensitySelector";
 import CardLightbox from "./CardLightbox";
 import CardFaceToggle from "./CardFaceToggle";
@@ -66,8 +69,6 @@ function sortCards(cards: SetCard[], key: SortKey): SetCard[] {
   return sorted;
 }
 
-type PrintingFilter = "all" | "new" | "reprints";
-
 export default function SetCardGrid({
   cards,
   setCode,
@@ -77,20 +78,47 @@ export default function SetCardGrid({
   setCode: string;
   backFaceUrls?: Record<string, { normal: string; art_crop?: string }>;
 }) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const publishCounts = usePublishExpansionCounts();
+
   const { imageMode, toggleImageMode, cardUrl } = useImageMode();
   const { density, setDensity } = useGridDensity();
   const [lightboxIdx, setLightboxIdx] = useState<number | null>(null);
   const [sortKey, setSortKey] = useState<SortKey>("number");
-  const [rarityFilter, setRarityFilter] = useState<Set<string>>(new Set());
-  const [printingFilter, setPrintingFilter] = useState<PrintingFilter>("all");
+
+  const { rarities: rarityFilter, printing: printingFilter } = useMemo(
+    () => parseSetFilterParams(searchParams),
+    [searchParams],
+  );
 
   const hasReprints = useMemo(() => cards.some((c) => c.is_reprint), [cards]);
 
+  const updateUrlParams = useCallback(
+    (mutator: (sp: URLSearchParams) => void) => {
+      const next = new URLSearchParams(searchParams?.toString() ?? "");
+      mutator(next);
+      const qs = next.toString();
+      router.replace(qs ? `${pathname}?${qs}` : pathname, { scroll: false });
+    },
+    [router, pathname, searchParams],
+  );
+
   const toggleRarity = (r: string) => {
-    setRarityFilter((prev) => {
-      const next = new Set(prev);
-      if (next.has(r)) next.delete(r); else next.add(r);
-      return next;
+    updateUrlParams((sp) => {
+      const current = new Set((sp.get("rarities") ?? "").split(",").filter(Boolean));
+      if (current.has(r)) current.delete(r); else current.add(r);
+      if (current.size > 0) sp.set("rarities", Array.from(current).join(","));
+      else sp.delete("rarities");
+    });
+    setLightboxIdx(null);
+  };
+
+  const setPrintingFilter = (value: PrintingFilter) => {
+    updateUrlParams((sp) => {
+      if (value === "all") sp.delete("printing");
+      else sp.set("printing", value);
     });
     setLightboxIdx(null);
   };
@@ -107,6 +135,23 @@ export default function SetCardGrid({
     }
     return sortCards(result, sortKey);
   }, [cards, rarityFilter, sortKey, printingFilter]);
+
+  // Publish unique-oracle counts to the sidebar bracket panel. The bracket
+  // pool is built server-side by deduping printings to one-per-oracle_id, so
+  // these counts must match or the size picker will offer sizes larger than
+  // the actual pool (and createBracket() will fall back to an Initial Round
+  // for a non-power-of-2 sub-selection).
+  const uniqueFilteredCount = useMemo(
+    () => new Set(filtered.map((c) => c.oracle_id)).size,
+    [filtered],
+  );
+  const uniqueTotalCount = useMemo(
+    () => new Set(cards.map((c) => c.oracle_id)).size,
+    [cards],
+  );
+  useEffect(() => {
+    publishCounts({ setCode, filteredCount: uniqueFilteredCount, totalCount: uniqueTotalCount });
+  }, [publishCounts, setCode, uniqueFilteredCount, uniqueTotalCount]);
 
   return (
     <>

--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -3,6 +3,8 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useImageMode } from "@/lib/image-mode";
+import CreateBracketPanel from "./CreateBracketPanel";
+import MobileBracketFab from "./MobileBracketFab";
 
 function ArtCardToggle() {
   const { imageMode, toggleImageMode } = useImageMode();
@@ -105,11 +107,15 @@ function getDetailContext(pathname: string): PlayLink[] | null {
 export default function Sidebar({ children }: { children?: React.ReactNode }) {
   const pathname = usePathname();
   const playLinks = getDetailContext(pathname);
+  const isExpansionPage = /^\/db\/expansions\/[^/]+$/.test(pathname);
 
   return (
-    <aside className="hidden lg:block w-[300px] shrink-0 pt-[7rem]">
+    <>
+      {isExpansionPage && <MobileBracketFab />}
+      <aside className="hidden lg:block w-[300px] shrink-0 pt-[7rem]">
       <div className="space-y-6">
         {children}
+        {isExpansionPage && <CreateBracketPanel />}
         {playLinks && playLinks.length > 0 ? (
           <div className="bg-gray-900 border border-gray-800 rounded-lg p-4">
             <ArtCardToggle />
@@ -131,6 +137,7 @@ export default function Sidebar({ children }: { children?: React.ReactNode }) {
           </div>
         )}
       </div>
-    </aside>
+      </aside>
+    </>
   );
 }

--- a/web/src/lib/bracket.ts
+++ b/web/src/lib/bracket.ts
@@ -10,3 +10,61 @@ export async function getRandomBracketCards(count = 32): Promise<BracketCard[]> 
   if (error) throw new Error(`Failed to get bracket cards: ${error.message}`);
   return data as BracketCard[];
 }
+
+export interface SetBracketFilters {
+  rarities?: string[];
+  printing?: "all" | "new" | "reprints";
+}
+
+/** Get bracket cards for a set with optional rarity/printing filters.
+ * Returns one BracketCard per unique oracle_id in stable collector-number order
+ * so a seeded shuffle on the client produces a deterministic pool. */
+export async function getBracketCardsForSet(
+  setCode: string,
+  filters: SetBracketFilters = {},
+): Promise<BracketCard[]> {
+  let query = getAdminClient()
+    .from("printings")
+    .select(
+      "oracle_id, illustration_id, artist, set_code, collector_number, image_version, rarity, is_reprint, sets!inner(name, digital), oracle_cards!inner(name, slug, type_line)",
+    )
+    .eq("set_code", setCode)
+    .not("illustration_id", "is", null)
+    .eq("sets.digital", false);
+
+  if (filters.rarities && filters.rarities.length > 0) {
+    query = query.in("rarity", filters.rarities);
+  }
+  if (filters.printing === "new") {
+    query = query.eq("is_reprint", false);
+  } else if (filters.printing === "reprints") {
+    query = query.eq("is_reprint", true);
+  }
+
+  const { data, error } = await query.order("collector_number", { ascending: true });
+  if (error) throw new Error(`Failed to load bracket cards for set: ${error.message}`);
+  if (!data || data.length === 0) return [];
+
+  // Deduplicate: one BracketCard per unique oracle_id (first collector number wins)
+  const seen = new Set<string>();
+  const out: BracketCard[] = [];
+  for (const p of data) {
+    if (seen.has(p.oracle_id)) continue;
+    seen.add(p.oracle_id);
+    const card = p.oracle_cards as unknown as { name: string; slug: string; type_line: string | null };
+    const set = p.sets as unknown as { name: string };
+    out.push({
+      oracle_id: p.oracle_id,
+      name: card.name,
+      slug: card.slug,
+      type_line: card.type_line,
+      artist: p.artist,
+      set_code: p.set_code,
+      set_name: set.name,
+      collector_number: p.collector_number,
+      illustration_id: p.illustration_id,
+      image_version: p.image_version,
+    });
+  }
+  return out;
+}

--- a/web/src/lib/expansion-context.tsx
+++ b/web/src/lib/expansion-context.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { createContext, useContext, useState, useCallback, type ReactNode } from "react";
+
+interface ExpansionCountState {
+  setCode: string | null;
+  filteredCount: number;
+  totalCount: number;
+}
+
+interface ExpansionContextValue extends ExpansionCountState {
+  publishCounts: (s: ExpansionCountState) => void;
+}
+
+const ExpansionContext = createContext<ExpansionContextValue | null>(null);
+
+export function ExpansionProvider({ children }: { children: ReactNode }) {
+  const [state, setState] = useState<ExpansionCountState>({
+    setCode: null,
+    filteredCount: 0,
+    totalCount: 0,
+  });
+
+  const publishCounts = useCallback((s: ExpansionCountState) => {
+    setState((prev) => {
+      if (prev.setCode === s.setCode && prev.filteredCount === s.filteredCount && prev.totalCount === s.totalCount) {
+        return prev;
+      }
+      return s;
+    });
+  }, []);
+
+  return (
+    <ExpansionContext.Provider value={{ ...state, publishCounts }}>
+      {children}
+    </ExpansionContext.Provider>
+  );
+}
+
+export function useExpansionCounts() {
+  const ctx = useContext(ExpansionContext);
+  if (!ctx) return { setCode: null, filteredCount: 0, totalCount: 0 };
+  return { setCode: ctx.setCode, filteredCount: ctx.filteredCount, totalCount: ctx.totalCount };
+}
+
+export function usePublishExpansionCounts() {
+  const ctx = useContext(ExpansionContext);
+  return ctx?.publishCounts ?? (() => {});
+}

--- a/web/src/lib/play-modes.tsx
+++ b/web/src/lib/play-modes.tsx
@@ -22,3 +22,6 @@ export function PlayModeIcon({ d, className = "w-5 h-5" }: { d: string; classNam
     </svg>
   );
 }
+
+// Bracket-tree icon: four seeds → two → one final. Heroicons v1 outline style.
+export const BRACKET_ICON = "M4 5 H8 M4 9 H8 M4 15 H8 M4 19 H8 M8 5 V9 M8 15 V19 M8 7 H12 M8 17 H12 M12 7 V17 M12 12 H20";

--- a/web/src/lib/seeded-random.ts
+++ b/web/src/lib/seeded-random.ts
@@ -1,0 +1,32 @@
+/** FNV-1a hash of a string to a 32-bit unsigned integer. */
+export function hashSeed(seed: string): number {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < seed.length; i++) {
+    h ^= seed.charCodeAt(i);
+    h = Math.imul(h, 0x01000193);
+  }
+  return h >>> 0;
+}
+
+/** Mulberry32 — small fast PRNG with good distribution for shuffles. */
+export function mulberry32(seed: number): () => number {
+  let state = seed >>> 0;
+  return function () {
+    state = (state + 0x6d2b79f5) >>> 0;
+    let t = state;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/** Fisher-Yates shuffle using a seeded PRNG — deterministic given the same seed. */
+export function seededShuffle<T>(arr: T[], seed: string): T[] {
+  const rand = mulberry32(hashSeed(seed));
+  const copy = arr.slice();
+  for (let i = copy.length - 1; i > 0; i--) {
+    const j = Math.floor(rand() * (i + 1));
+    [copy[i], copy[j]] = [copy[j], copy[i]];
+  }
+  return copy;
+}

--- a/web/src/lib/set-filters.ts
+++ b/web/src/lib/set-filters.ts
@@ -1,0 +1,40 @@
+import type { SetCard } from "./types";
+
+export type PrintingFilter = "all" | "new" | "reprints";
+
+export interface SetFilterParams {
+  rarities: Set<string>;
+  printing: PrintingFilter;
+}
+
+export function parseSetFilterParams(sp: URLSearchParams | null | undefined): SetFilterParams {
+  const raritiesRaw = sp?.get("rarities") ?? "";
+  const rarities = new Set(raritiesRaw.split(",").map((s) => s.trim()).filter(Boolean));
+  const printingRaw = sp?.get("printing") ?? "all";
+  const printing: PrintingFilter = printingRaw === "new" || printingRaw === "reprints" ? printingRaw : "all";
+  return { rarities, printing };
+}
+
+export function applySetFilters(cards: SetCard[], params: SetFilterParams): SetCard[] {
+  let result = cards;
+  if (params.rarities.size > 0) {
+    result = result.filter((c) => params.rarities.has(c.rarity ?? "common"));
+  }
+  if (params.printing === "new") {
+    result = result.filter((c) => !c.is_reprint);
+  } else if (params.printing === "reprints") {
+    result = result.filter((c) => c.is_reprint);
+  }
+  return result;
+}
+
+export function setFilterParamsToSearchString(params: SetFilterParams): string {
+  const sp = new URLSearchParams();
+  if (params.rarities.size > 0) {
+    sp.set("rarities", Array.from(params.rarities).join(","));
+  }
+  if (params.printing !== "all") {
+    sp.set("printing", params.printing);
+  }
+  return sp.toString();
+}


### PR DESCRIPTION
## Summary

- Adds a **Create Bracket** panel to the `/db/expansions/[set_code]` sidebar (plus a mobile FAB) that builds a shareable `/bracket?set_code=...&rarities=...&printing=...&size=...&seed=...` URL.
- Expansion rarity/printing filters now live in URL params so the sidebar and grid share one source of truth.
- New `GET /api/bracket/from-set` applies filters + a deterministic seeded shuffle — the same URL always produces the same pool and round-1 pairings, which makes brackets shareable.
- Sidebar counts are unique-by-oracle so the size picker (8/16/32/64/128/All) only offers sizes the pool can actually deliver. Avoids the "click 128 → get an Initial Round + Round of 64" fallback for sub-power-of-2 pools.

## New files

- `web/src/app/api/bracket/from-set/route.ts` — new API route
- `web/src/components/CreateBracketPanel.tsx` — shared panel (desktop sidebar + mobile sheet)
- `web/src/components/MobileBracketFab.tsx` — `lg:hidden` floating Play button + bottom sheet
- `web/src/lib/expansion-context.tsx` — publishes filtered/total counts from `SetCardGrid` to the sidebar
- `web/src/lib/seeded-random.ts` — mulberry32 + FNV-1a for deterministic shuffles
- `web/src/lib/set-filters.ts` — shared filter predicate + URL param parsing
- `BRACKET_ICON` path added to `lib/play-modes.tsx`, rendered via existing `PlayModeIcon`

## Test plan

- [ ] `/db/expansions/soa` — sidebar shows Create Bracket panel with "65 cards", only 8/16/32/All enabled (65 < 64)
- [ ] `/db/expansions/dsk` — all six sizes enabled
- [ ] Apply rarity filter (e.g. Mythic) on soa → count drops, URL gains `?rarities=mythic`, filtered count matches pool
- [ ] Pick a size and click **Launch Bracket** — navigates to `/bracket?set_code=...&size=...&seed=...`
- [ ] Copy the bracket URL to a new tab → identical pool + matchups (determinism)
- [ ] Restart from inside the bracket → new seed in URL, fresh shuffle from same pool
- [ ] Mobile viewport: FAB appears bottom-right, sheet opens with the same picker, Escape closes
- [ ] Non-power-of-2 pool via `size=all` still builds correctly (Initial Round strategy from CLAUDE.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)